### PR TITLE
Updated references to the Console 

### DIFF
--- a/src/deploying/deploying_via_cli.md
+++ b/src/deploying/deploying_via_cli.md
@@ -21,13 +21,13 @@ Now, you can use the `heroku` command for your projects, as described in the [He
 
 ### Free and Premium Plans
 
-In [the console](./console.html), type the following:
+In [the Console](./console.html) or [a Terminal](./terminal.html), type the following:
 
 ```bash
 npm install azure
 ```
 
-Now, you can use the `azure` command from the console. For more information, read [the official `azure` documentation](https://github.com/WindowsAzure/azure-sdk-for-node).
+Now, you can use the `azure` command from the Console/Terminal. For more information, read [the official `azure` documentation](https://github.com/WindowsAzure/azure-sdk-for-node).
 
 ### Premium Plans
 
@@ -52,7 +52,7 @@ For free and premium plans, follow the instructions on the [azure-cmdlet-node](h
 
 ## CloudFoundry
 
-To deploy to CloudFoundry from the command line, type:
+To deploy to CloudFoundry from the command line in [the Console](./console.html) or [a Terminal](./terminal.html), type:
 
 ```
 cd ~
@@ -67,7 +67,7 @@ bundle
 
 ### Free and Premium Plans
 
-On the console, type:
+In the [the Console](./console.html) or [a Terminal](./terminal.html), type:
 
 ```bash
 npm install jitsu@0.7.x -g
@@ -83,4 +83,4 @@ Now, you can run `jitsu` from the command line. For more information, see [the o
 npm install jitsu@0.7.x -g
 ```
 
-You can now run `jitsu` from both the console and the terminal.
+You can now run `jitsu` from both the Console and the Terminal.

--- a/src/features/gotofile_and_definition.md
+++ b/src/features/gotofile_and_definition.md
@@ -4,13 +4,15 @@
 <iframe width="640" height="360" src="https://www.youtube.com/embed/U5823J0kYLE" frameborder="0" allowfullscreen></iframe>
 </div>
 
-Let's say you're workinng a large project containing many files, and you kind-of sort-of know the name of a file that you want to open up. Goto File is our feature to help you quickly and easily jump to any file in your workspace, without the need to search through different directories. Simply hit `Cmd-E` (or `Ctrl-E` on Unix/Windows) and away you go:  
+Let's say you're working a large project containing many files, and you kind-of sort-of know the name of a file that you want to open up. Goto File is our feature to help you quickly and easily jump to any file in your workspace, without the need to search through different directories. Simply hit `Cmd-E` (or `Ctrl-E` on Unix/Windows) and away you go:  
+
 ![Goto File Window](./resources/images/gotofile.png)<505, 400>
 
 
 Goto File offers filtering for any portion of a filename, including directories. Search for the beginning, middle, or end of a file path, or even just an extension, like `.js`, and Goto File with instantly present the results to you. Clicking on a name in the list opens the file right up. Goto File does not support case-insensitive, wildcard (`*`, `?`), or regular expression (`.`, `+`) searching.
 
 Goto Definition takes the same concept and applies it to files. You can easily navigate between classes and members defined in your files. By entering text, you can filter your class' member results. Finally, as you navigate through your file, Cloud9 IDE will jump to the relevant portion of the code:  
+
 ![Goto Definition Window](./resources/images/gotodefinition.png)<864, 400>
 
 

--- a/src/ide-components/console.md
+++ b/src/ide-components/console.md
@@ -1,16 +1,14 @@
 # The Console
 
-The console is at the bottom of the IDE. It's where you can enter command line input, view output from your program, and push and pull your files between your code repositories. 
+The Console is at the bottom of the IDE. It's where you can enter command line input, view output from your program, and push and pull your files between your code repositories. 
 
-Note: The console is different than [the terminal](./terminal.html) in several ways, primarily that it can't run a full set of Unix commands.
+Note: The Console contains [a full-fledged terminal](./terminal.html), which provides you with a TTY interface for _direct access_ to the machine that Cloud9 is running on.
 
 ## Available Commands
 
-You can use many common Unix commands, such as `ls` and `mkdir`, in the console space. To preview the full list of basic commands in the console, you can type `help` and press Enter. For every command, a description is provided:
-
-![Screenshot of the available commands](./resources/images/availableCommands.png)<907, 422>
-
-You can also use mercurial commands (`hg`) and git commands (`git`) to communicate with the system, and to push your code between repositories. Typing `hg` or `git` shows the complete list of commands that are available for these services. For more information about these commands, please check their respective documentation:
+The terminal can perform all Unix commands, and allows for path autocompletion by hitting [[keys: Tab]].
+ 
+For instance, you can use mercurial commands (`hg`) and git commands (`git`) to communicate with the system, and to push your code between repositories. Typing `hg` or `git` shows the complete list of commands that are available for these services. For more information about these commands, please check their respective documentation:
 
 * [Mercurial Command List](http://mercurial.selenic.com/guide)
 * [Git Command List](http://help.github.com/git-cheat-sheets)
@@ -20,16 +18,12 @@ To use mercurial commands on the project you are working on, you must have a mer
 * [Setting up a Mercurial Project](./setting_up_bitbucket_workspace.html)
 * [Setting up a Git project (on GitHub)](./setting_up_github_workspace.html)
 
-Those articles also explain how to use the command-line to commit your work.
-
-In addition, the console also has shortcuts for much of Cloud9 IDE's functionality. For example, `gotofile` launches the filename you provide, while `revealtab` opens the current file in the project tree. Again, typing `help` shows you which commands are available.
-
 ## Output
 
-The output tab in the console shows information whenever a user is running or debugging a program. The content is similar to the output of a desktop terminal:  
-![Screenshot of program output](./resources/images/consoleOutput.png)<1174 336>
+The output tab in the Console shows information whenever a user is running or debugging a program. The content is similar to the output of a desktop terminal:  
+![Screenshot of program output](./resources/images/consoleOutput.png)<1174, 336>
 
-The output tab also displays the error and additional information that can improve your coding quality. You can use the console to output results from your running application, just like a regular terminal.
+The output tab also displays the error and additional information that can improve your coding quality. You can use the Console to output results from your running application, just like a regular terminal.
 
 As your process runs, you'll see a message similar to this one indicating that Cloud9 is running something in the background: ![Running process](./resources/images/runningProcess.png)<197, 29>
 

--- a/src/ide-components/terminal.md
+++ b/src/ide-components/terminal.md
@@ -4,10 +4,9 @@ The terminal provides you with a TTY interface for _direct access_ to the machin
 
 Warning: While certain operations, like `sudo`, are restricted, you **can** completely destroy your workspace, by doing something like `rm -rf`.  Use your power wisely!
 
-To create a new terminal, go to [[menu: View, Terminals, New Terminal]], or simply type [[keys: Alt-T]] on the keyboard. The terminal differs from [the console](./console.html) in several distinct ways, namely:
+To create a new terminal, go to [[menu: View, Terminals, New Terminal]], or simply type [[keys: Alt-T]] on the keyboard. The terminal has the following capabilities:
 
-* The terminal can perform all Unix commands, not just a subset
-* The terminal can't launch Cloud9 specific commands, like `nexttab` or `gotofile`
+* Perform all Unix commands
 * You can create more than one instance of a terminal (by just creating a new tab)
 * The terminal allows for path autocompletion by hitting [[keys: Tab]]
 

--- a/src/running_and_debugging/running_wordpress_on_cloud9.md
+++ b/src/running_and_debugging/running_wordpress_on_cloud9.md
@@ -87,7 +87,7 @@ Now it's time to push this platform to a hosted service. We'll be using Heroku a
 
 1. Click on the **Deploy** icon in the project bar, and click on the plus icon to add a new deployment target
 2. Select Heroku from the dropdown list, and enter your login credentials
-3. In the Cloud9 IDE console, enter the following commands:
+3. In a Cloud9 IDE terminal (e.g. in the Console on the bottom), enter the following commands:
 ```
 git remote add heroku git@heroku.com:APPNAME.git
 git add .


### PR DESCRIPTION
Changed the Console references (which now has a mini Terminal) that I could find in the documentation in various pages and fixed a small typo. Screenshots will still need to be updated at a later time.

@lennartcl Can you take a look?
