### PR TITLE
Fixes 'Wordpress' typos

### DIFF
--- a/src/running_and_debugging/editing_wordpress_sites.md
+++ b/src/running_and_debugging/editing_wordpress_sites.md
@@ -1,11 +1,11 @@
-# Editing Remote Wordpress Websites via FTP
+# Editing Remote WordPress Websites via FTP
 
 <div class="video-container">
 <iframe width="640" height="480" src="https://www.youtube.com/embed/3vZIKzALxyU" frameborder="0" allowfullscreen></iframe>
 </div>
 
-Did you know that you can use Cloud9 IDE to work on your Wordpress website? It's true, and incredibly easy. You can't edit your posts on Wordpress using Cloud9, since they are stored in a database on your server. But you can edit pretty much every other aspect of your site.
+Did you know that you can use Cloud9 IDE to work on your WordPress website? It's true, and incredibly easy. You can't edit your posts on WordPress using Cloud9, since they are stored in a database on your server. But you can edit pretty much every other aspect of your site.
 
 To start, you'll need to [create a new FTP project](./ftp_workspaces.html). After that, enter your _wp-content_ folder, find the theme you're using on your website, and start editing its style.
 
-Thanks to [the preview button](./ide_overview.html#previewButton) in the menu bar, you can also witness your changes as they happen, before commiting them to your server.
+Thanks to [the preview button](./ide_overview.html#previewButton) in the menu bar, you can also witness your changes as they happen, before committing them to your server.

--- a/src/running_and_debugging/running_wordpress_on_cloud9.md
+++ b/src/running_and_debugging/running_wordpress_on_cloud9.md
@@ -1,15 +1,15 @@
-# Running Wordpress on Cloud9
+# Running WordPress on Cloud9
 
-Wordpress is web software you can use to create websites or blogs.
-You can develop and host Wordpress websites entirely on Cloud9 IDE
+WordPress is web software you can use to create websites or blogs.
+You can develop and host WordPress websites entirely on Cloud9 IDE
 
 ### Creating a wordpress workspace
 
-Create a Wordpress workspace from the Wordpress template on your Cloud9 dashboard
+Create a WordPress workspace from the WordPress template on your Cloud9 dashboard
 
-Note: We will download, extract and configure Wordpress for you.
+Note: We will download, extract and configure WordPress for you.
 
-In order to run Wordpress, you need a database to host your posts, articles, etc.
+In order to run WordPress, you need a database to host your posts, articles, etc.
 
 You can use MySQL with our utility script _**mysql-ctl**_ as explained in [MySQL Setup](./setting_up_mysql.html)
 

--- a/src/running_and_debugging/writing_a_php_app.md
+++ b/src/running_and_debugging/writing_a_php_app.md
@@ -26,6 +26,6 @@ Running Apache Process
 Tip: you can access long running processes, like a server, at 'http://php_hello.gjtorikian.c9.io'.
 ```
 
-Clicking on that link gets you to your PHP page. For a more in-depth workflow, see the article on [running Wordpress entirely on Cloud9](./running_wordpress_on_cloud9.html).
+Clicking on that link gets you to your PHP page. For a more in-depth workflow, see the article on [running WordPress entirely on Cloud9](./running_wordpress_on_cloud9.html).
 
 Note: Currently, you can't debug PHP applications, but we are working on adding this feature.

--- a/templates/default/toc.jade
+++ b/templates/default/toc.jade
@@ -116,9 +116,9 @@
               a(href='writing_a_php_app.html') Writing a PHP App
               ul
                 li.nav-submenu-item
-                  a(href='editing_wordpress_sites.html') Editing Remote Wordpress Websites
+                  a(href='editing_wordpress_sites.html') Editing Remote WordPress Websites
                 li.nav-submenu-item
-                  a(href="running_wordpress_on_cloud9.html") Running Wordpress on Cloud9
+                  a(href="running_wordpress_on_cloud9.html") Running WordPress on Cloud9
             li.nav-submenu-item
               a(href='writing_a_go_app.html') Writing a Go App
         li.nav-section


### PR DESCRIPTION
See http://wordpress.org/about/

Changed files:

```
src/running_and_debugging/editing_wordpress_sites.md
src/running_and_debugging/running_wordpress_on_cloud9.md
src/running_and_debugging/writing_a_php_app.md
templates/default/toc.jade
```
