### PR TITLE
Use https for YouTube video iframe.

### DIFF
--- a/src/features/collaboration.md
+++ b/src/features/collaboration.md
@@ -31,5 +31,5 @@ To make the experience even smoother you can choose "Always merge by default" an
 Check out the video below to see this in action.
 
 <div class="video-container">
-<iframe width="560" height="315" src="http://www.youtube.com/embed/8sstjmj8P6E" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/8sstjmj8P6E" frameborder="0" allowfullscreen></iframe>
 </div>


### PR DESCRIPTION
The YouTube video for the [collaboration page](https://docs.c9.io/collaboration.html) currently doesn't load in Firefox because the page is secure (https) and the video URL is insecure (http).

This pull request fixes the video on https://docs.c9.io/collaboration.html by loading the video over https always.
