### PR TITLE
Making MySQL Default database.

### DIFF
--- a/src/running_and_debugging/running_a_rails_app.md
+++ b/src/running_and_debugging/running_a_rails_app.md
@@ -17,9 +17,8 @@ Do **not** try to access the project through the IP address and port number rail
 
 ## Use MySQL in your rails app
 
-1. Install `mysql2` adapter by typing in terminal: `gem install mysql2`
 
-2. [Setup MySQl](./setting_up_mysql.html) - note your DB connect parameters
+1. [Setup MySQl](./setting_up_mysql.html) - note your DB connect parameters
 
 3. edit `configs/database.yml`
 


### PR DESCRIPTION
Since c9 is telling user to use MySQL in rails app so it's better to create database.yml settings for MySQL by default by passing "-d DatabaseName", as well as for other databases also what ever c9 in supporting.
