### PR TITLE
Update syntax_highlighting_themes.md

### DIFF
--- a/src/features/syntax_highlighting_themes.md
+++ b/src/features/syntax_highlighting_themes.md
@@ -44,6 +44,7 @@ We support highlighting for at least the following languages, and many more:
 * ColdFusion
 * C#
 * CSS
+* Dart
 * Go
 * Groovy
 * haXe


### PR DESCRIPTION
Update syntax_highlighting_themes.md to include `Dart` in the list of syntax highlighted languages.
