### PR TITLE
Update writing_a_php_app.html

### DIFF
--- a/out/writing_a_php_app.html
+++ b/out/writing_a_php_app.html
@@ -187,7 +187,7 @@
             <div id="content">
               <div id="toh_btn" onclick="toggleTOH(this)"></div>
               <h1>Writing a PHP App</h1>
-              <div><p>With Cloud9 IDE, you can run your PHP pages, without relying on a third-party system like Apache hosting. We run PHP version 5.3.3.</p>
+              <div><p>With Cloud9 IDE, you can run your PHP pages, without relying on a third-party system like Apache hosting. We run PHP version 5.5.9.</p>
 <p>You can choose to run PHP scripts via the command line, by typing <code>php</code>, followed by the name of your PHP file. However, this is not a very common use case. Most likely, you&#39;ll be running your own server and hosting PHP files.</p>
 <p>Here&#39;s a simple demonstration. First, create a PHP file called <em>hello_world.php</em>, and paste this code into it:</p>
 <pre><code class="language-xml"><span class="tag">&lt;<span class="title">html</span>&gt;</span>


### PR DESCRIPTION
c9 runs PHP version 5.5.9, but writing_a_php_app.html reads "We run PHP version 5.3.3.". I propose this sentence be changed to read "We run PHP version 5.5.9."