### PR TITLE
Update frameworks_jekyll.md

### DIFF
--- a/src/frameworks/frameworks_jekyll.md
+++ b/src/frameworks/frameworks_jekyll.md
@@ -5,6 +5,6 @@ Jekyll is a great static site generator, also used by github pages. You simply n
     $ gem install jekyll
     $ jekyll new my-awesome-site
     $ cd my-awesome-site
-    $ jekyll serve --port $PORT
+    $ jekyll serve --host $IP --port $PORT --baseurl ''
 
 <iframe width="640" height="480" src="//www.youtube.com/embed/xdxfyFS3pog" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
This line of code may prove to be more helpful to newcomers:
```
jekyll serve --host $IP --port $PORT --baseurl ''
```
```--baseurl``` (passing an empty string) seems to be required to test locally, if it is already defined in **_config.yml** (per documentation http://jekyllrb.com/docs/github-pages/#project-page-url-structure)
```--port``` is necessary for Cloud9.
```--host``` appears to be unnecessary, but may be better to include for practice.