### PR TITLE
Add hostname command-line flag

### DIFF
--- a/src/frameworks/frameworks_jekyll.md
+++ b/src/frameworks/frameworks_jekyll.md
@@ -5,6 +5,6 @@ Jekyll is a great static site generator, also used by github pages. You simply n
     $ gem install jekyll
     $ jekyll new my-awesome-site
     $ cd my-awesome-site
-    $ jekyll serve --port $PORT
+    $ jekyll serve --host $IP --port $PORT
 
 <iframe width="640" height="480" src="//www.youtube.com/embed/xdxfyFS3pog" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
In order to live preview Jekyll site in Cloud9 workspace hostname needs to be added to the jekyll serve command. 