### PR TITLE
Double sudo is needed so it was re-added

### DIFF
--- a/src/persistence/setting_up_postgresql.md
+++ b/src/persistence/setting_up_postgresql.md
@@ -10,27 +10,27 @@ PostgreSQL comes preinstalled on every Cloud9 workspace, yay.
 
 ### Set the "postgres" user password
 
-    $ sudo -u postgres psql                                                                                  
+    $ sudo sudo -u postgres psql
     psql (9.3.4, server 9.3.5)
     Type "help" for help.
-    
+
     postgres=# \password
-    Enter new password: 
-    Enter it again: 
+    Enter new password:
+    Enter it again:
     postgres=# \q
 
 ## Connect to the service
 
-    $ sudo -u postgres psql                                                                                  
+    $ sudo sudo -u postgres psql
 
 ## Create a PostgreSQL database
 
 Make sure you have logged into the PostgreSQL terminal and then you can just run:
 
-    $ sudo -u postgres psql                                                                                  
+    $ sudo sudo -u postgres psql
     postgres=# create database "groceries";
-    
+
 ## List all databases
 
-    $ sudo -u postgres psql                                                                                  
+    $ sudo sudo -u postgres psql
     postgres=# \list


### PR DESCRIPTION
Previous PR was merged to remove double sudos from being used. These are actually necessary to gain access to postgresql on Cloud9 so they've been added again.